### PR TITLE
Specify that no network access is needed

### DIFF
--- a/variant-switcher/CHANGELOG.md
+++ b/variant-switcher/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v9 (Feb 27, 2025)
+
+### Added
+
+-   Added Dynamic Loading to help the plugin load faster. ([#97](https://github.com/etn-ccis/blui-figma-plugins/pull/97); thanks, @andrewlevada!)
+-   Declared in manifest file that no network access is required for the plugin.
+
 ## v8 (May 8, 2023)
 
 ### Fixed

--- a/variant-switcher/manifest.json
+++ b/variant-switcher/manifest.json
@@ -5,5 +5,6 @@
     "main": "dist/code.js",
     "ui": "dist/ui.html",
     "editorType": ["figma", "figjam"],
-    "documentAccess": "dynamic-page"
+    "documentAccess": "dynamic-page",
+    "networkAccess": { "allowedDomains": ["none"] }
 }


### PR DESCRIPTION
- Added a line in manifest.json to declare that the plugin does not access any network (it's a plugin that runs locally).

## To test
- Nothing to test. There used to be a Figma warning about it. After this change, I can tell that the Figma warning is already gone.